### PR TITLE
feat: add agent-aware response and FAQ section

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,34 @@ const HTML = `<!DOCTYPE html>
       margin-top: 2rem;
     }
 
+    /* FAQ section */
+    .faq-section {
+      margin-top: 3rem;
+    }
+    .faq-section h2 {
+      font-size: 1.4rem;
+      font-weight: 700;
+      margin: 0 0 1.25rem;
+    }
+    .faq-item {
+      border-bottom: 1px solid var(--border);
+      padding: 1rem 0;
+    }
+    .faq-item:last-child {
+      border-bottom: none;
+    }
+    .faq-item h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      margin: 0 0 0.4rem;
+    }
+    .faq-item p {
+      margin: 0;
+      color: var(--text);
+      font-size: 0.92rem;
+      line-height: 1.7;
+    }
+
     @media (max-width: 800px) {
       .main-grid {
         grid-template-columns: 1fr;
@@ -287,6 +315,46 @@ const HTML = `<!DOCTYPE html>
     </div>
   </div>
 
+  <!-- FAQ -->
+  <div class="faq-section">
+    <h2>FAQ</h2>
+
+    <div class="faq-item">
+      <h3>Are you open to new opportunities?</h3>
+      <p>Yes — I'm open to a conversation and exploring what you're working on. No pressure either way; if it's a good fit for both of us, great, and if not, no worries.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>What kind of work arrangements do you consider?</h3>
+      <p>Contract, contract-to-hire, or full-time. I'm flexible on structure as long as the work and team are a good fit.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>Do you work remotely? What timezone are you in?</h3>
+      <p>I'm fully remote, based in US Central Time (CST/CDT). I have a strong overlap with US timezones and am comfortable working with distributed teams across other regions.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>What are your rates?</h3>
+      <p>It depends on the scope, duration, and type of engagement — let's talk and figure out what makes sense for both sides.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>What does your tech stack look like?</h3>
+      <p>iOS/Swift for mobile, cloud platforms like AWS and Cloudflare for infrastructure and deployment automation, and Vue/TypeScript for web. I'm comfortable picking up new tools when the project calls for it.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>What kind of projects or roles are you a good fit for?</h3>
+      <p>Mobile (iOS) development, cloud infrastructure and deployment automation, feature development, and general full-stack work — from new concepts to optimizing existing systems.</p>
+    </div>
+
+    <div class="faq-item">
+      <h3>How do I get in touch?</h3>
+      <p>Email me at <a href="mailto:idelfonsog2@gmail.com">idelfonsog2@gmail.com</a> — happy to set up a call to discuss further.</p>
+    </div>
+  </div>
+
 </div>
 
 <footer>
@@ -296,12 +364,99 @@ const HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
+const AGENT_UA_PATTERNS = [
+  /GPTBot/i,
+  /ChatGPT-User/i,
+  /OAI-SearchBot/i,
+  /ClaudeBot/i,
+  /Claude-Web/i,
+  /Claude-User/i,
+  /anthropic-ai/i,
+  /PerplexityBot/i,
+  /Perplexity-User/i,
+  /Google-Extended/i,
+  /CCBot/i,
+  /cohere-ai/i,
+  /Bytespider/i,
+  /Amazonbot/i,
+  /Applebot-Extended/i,
+];
+
+const MARKDOWN = `# Idelfonso Gutierrez — Software Engineer
+
+Remote software engineer specializing in cloud-based applications, deployment automation, and mobile apps for the Apple ecosystem.
+
+## About
+
+As a dedicated software developer, I specialize in crafting cloud-based applications and orchestrating deployment automation. My expertise extends to defining feature requirements and creating sleek mobile apps, especially for the Apple ecosystem. My aim is streamlined, intuitive software that delights its users.
+
+When designed thoughtfully, technology can be powerful and wonderfully simple.
+
+I'm here to elevate your project by exploring a new concept, adding features, or optimizing operations.
+
+## Experience
+
+Worked across Enterprise, Healthcare, Retail, Agriculture, Financing, Outsourcing, Startup, and Ecommerce sectors, including:
+
+- Northwestern Medicine
+- Ulta Beauty
+- GrowIt
+- KIN+KARTA
+- YellowPepper
+- Ally's Flower
+
+## Recent Posts
+
+- Mastering iOS Provisioning: A Developer's Guide to Certificates & Profiles - Part 1 (4 min read)
+- PR Merged - Swift AWS Lambda Events (1 min read)
+- NSManagedObjectContext().refreshAllObjects {} (1 min read)
+
+## FAQ
+
+**Are you open to new opportunities?**
+Yes — open to a conversation and exploring what you're working on. No pressure either way; if it's a good fit for both sides, great, and if not, no worries.
+
+**What kind of work arrangements do you consider?**
+Contract, contract-to-hire, or full-time. Flexible on structure as long as the work and team are a good fit.
+
+**Do you work remotely? What timezone are you in?**
+Fully remote, based in US Central Time (CST/CDT). Strong overlap with US timezones and comfortable working with distributed teams across other regions.
+
+**What are your rates?**
+Depends on the scope, duration, and type of engagement — happy to discuss and figure out what makes sense for both sides.
+
+**What does your tech stack look like?**
+iOS/Swift for mobile, cloud platforms like AWS and Cloudflare for infrastructure and deployment automation, and Vue/TypeScript for web. Comfortable picking up new tools as needed.
+
+**What kind of projects or roles are you a good fit for?**
+Mobile (iOS) development, cloud infrastructure and deployment automation, feature development, and general full-stack work — from new concepts to optimizing existing systems.
+
+**How do I get in touch?**
+Email idelfonsog2@gmail.com — happy to set up a call.
+
+## Contact
+
+Email: idelfonsog2@gmail.com
+`;
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
     if (url.pathname !== "/" && url.pathname !== "") {
       return env.ASSETS.fetch(request);
+    }
+
+    const userAgent = request.headers.get("User-Agent") ?? "";
+    const isAgent = AGENT_UA_PATTERNS.some((pattern) => pattern.test(userAgent));
+
+    if (isAgent) {
+      return new Response(MARKDOWN, {
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          "Cache-Control": "public, max-age=300",
+        },
+      });
     }
 
     return new Response(HTML, {


### PR DESCRIPTION
## Summary
- Serve a lean Markdown response to known AI agent user-agents (GPTBot, ClaudeBot, PerplexityBot, etc.)
- Add an FAQ section (availability, work arrangements, rates, timezone, tech stack) to both human HTML and agent markdown views

## Test plan
- [ ] `npm run build` passes
- [ ] Verify FAQ renders on human page
- [ ] Verify markdown response for agent user-agent includes FAQ